### PR TITLE
Sync dependencies with AS7 upstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>8</version>
+        <version>9</version>
     </parent>
     
     <licenses>
@@ -142,47 +142,47 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
-            <version>1.3.1.Final</version>
+            <version>1.4.0.Beta1</version>
         </dependency>    
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.1.1.GA</version>
+            <version>3.1.2.GA</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>1.0.3.Final</version>
+            <version>1.1.0.Beta1</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
-            <version>1.3.15.GA</version>
+            <version>1.3.16.GA</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-            <version>1.3.15.GA</version>
+            <version>1.3.16.GA</version>
         </dependency>        
         <dependency>
             <groupId>org.jboss.remoting3</groupId>
             <artifactId>jboss-remoting</artifactId>
-            <version>3.2.8.GA</version>
+            <version>3.2.12.GA</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>
             <artifactId>jboss-sasl</artifactId>
-            <version>1.0.1.Final</version>
+            <version>1.0.3.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-api</artifactId>
-            <version>3.0.5.GA</version>
+            <version>3.0.7.GA</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-nio</artifactId>
-            <version>3.0.5.GA</version>
+            <version>3.0.7.GA</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Current version has dependency to jboss-remoting 3.2.8.GA which in combination with current upstream's 3.2.12.GA causes frequent hangs
