### PR TITLE
[REMJMX-68] ClientConnection should propagate JMRuntimeException

### DIFF
--- a/src/main/java/org/jboss/remotingjmx/protocol/v1/ClientConnection.java
+++ b/src/main/java/org/jboss/remotingjmx/protocol/v1/ClientConnection.java
@@ -88,6 +88,7 @@ import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.InvalidAttributeValueException;
+import javax.management.JMRuntimeException;
 import javax.management.ListenerNotFoundException;
 import javax.management.MBeanException;
 import javax.management.MBeanInfo;
@@ -101,7 +102,6 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.QueryExp;
 import javax.management.ReflectionException;
-import javax.management.RuntimeMBeanException;
 import javax.security.auth.Subject;
 
 import org.jboss.logging.Logger;
@@ -533,7 +533,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain createMBean, status=" + result.toString());
@@ -591,7 +591,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -656,7 +656,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke createMBean, status=" + result.toString());
@@ -725,7 +725,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke createMBean, status=" + result.toString());
@@ -769,7 +769,7 @@ class ClientConnection extends Common implements VersionedConnection {
 
                         instanceNotFoundException(response.e);
                         mbeanRegistrationException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke unregisterMBean, status=" + result.toString());
@@ -810,7 +810,7 @@ class ClientConnection extends Common implements VersionedConnection {
                             return response.value;
                         }
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke getObjectInstance, status=" + result.toString());
@@ -853,7 +853,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke queryMBeans, status=" + result.toString());
@@ -896,7 +896,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -934,7 +934,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -967,7 +967,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -1017,7 +1017,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         attributeNotFoundException(response.e);
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -1066,7 +1066,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         }
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke getAttributes, status=" + result.toString());
@@ -1117,7 +1117,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         invalidAttributeValueException(response.e);
                         mbeanException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke setAttribute, status=" + result.toString());
@@ -1163,7 +1163,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         }
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke setAttributes, status=" + result.toString());
@@ -1230,7 +1230,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         instanceNotFoundException(response.e);
                         mbeanException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke invoke(), status=" + result.toString());
@@ -1262,7 +1262,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -1296,7 +1296,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -1356,7 +1356,7 @@ class ClientConnection extends Common implements VersionedConnection {
 
                         localNotificationManager.cancel(notificationId);
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         localNotificationManager.cancel(notificationId);
@@ -1409,7 +1409,7 @@ class ClientConnection extends Common implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1459,7 +1459,7 @@ class ClientConnection extends Common implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1516,7 +1516,7 @@ class ClientConnection extends Common implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1565,7 +1565,7 @@ class ClientConnection extends Common implements VersionedConnection {
 
                         instanceNotFoundException(response.e);
                         listenerNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke removeNotificationListener, status=" + result.toString());
@@ -1620,7 +1620,7 @@ class ClientConnection extends Common implements VersionedConnection {
                         instanceNotFoundException(response.e);
                         introspectionException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -1663,7 +1663,7 @@ class ClientConnection extends Common implements VersionedConnection {
                             return response.value;
                         }
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -1733,9 +1733,9 @@ class ClientConnection extends Common implements VersionedConnection {
             }
         }
 
-        private void runtimeMBeanException(Exception e) {
-            if (e instanceof RuntimeMBeanException) {
-                throw (RuntimeMBeanException) e;
+        private void jmRuntimeException(Exception e) {
+            if (e instanceof JMRuntimeException) {
+                throw (JMRuntimeException) e;
             }
         }
 

--- a/src/main/java/org/jboss/remotingjmx/protocol/v2/ClientConnection.java
+++ b/src/main/java/org/jboss/remotingjmx/protocol/v2/ClientConnection.java
@@ -78,6 +78,7 @@ import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.InvalidAttributeValueException;
+import javax.management.JMRuntimeException;
 import javax.management.ListenerNotFoundException;
 import javax.management.MBeanException;
 import javax.management.MBeanInfo;
@@ -369,7 +370,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain createMBean, status=" + result.toString());
@@ -427,7 +428,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -492,7 +493,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke createMBean, status=" + result.toString());
@@ -561,7 +562,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         mbeanRegistrationException(response.e);
                         mbeanException(response.e);
                         notCompliantMBeanException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke createMBean, status=" + result.toString());
@@ -605,7 +606,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
 
                         instanceNotFoundException(response.e);
                         mbeanRegistrationException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke unregisterMBean, status=" + result.toString());
@@ -646,7 +647,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                             return response.value;
                         }
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke getObjectInstance, status=" + result.toString());
@@ -689,7 +690,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke queryMBeans, status=" + result.toString());
@@ -732,7 +733,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -770,7 +771,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -803,7 +804,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -853,7 +854,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         attributeNotFoundException(response.e);
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -902,7 +903,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         }
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke getAttributes, status=" + result.toString());
@@ -953,7 +954,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         invalidAttributeValueException(response.e);
                         mbeanException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke setAttribute, status=" + result.toString());
@@ -999,7 +1000,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         }
                         instanceNotFoundException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke setAttributes, status=" + result.toString());
@@ -1066,7 +1067,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         instanceNotFoundException(response.e);
                         mbeanException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke invoke(), status=" + result.toString());
@@ -1098,7 +1099,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -1132,7 +1133,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         if (response.e == null) {
                             return response.value;
                         }
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     case FAILED:
                         throw future.getException();
@@ -1192,7 +1193,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
 
                         localNotificationManager.cancel(notificationId);
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         localNotificationManager.cancel(notificationId);
@@ -1245,7 +1246,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1295,7 +1296,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1352,7 +1353,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                             return;
                         }
 
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         instanceNotFoundException(response.e);
                         throw toIoException(response.e);
                     default:
@@ -1401,7 +1402,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
 
                         instanceNotFoundException(response.e);
                         listenerNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to invoke removeNotificationListener, status=" + result.toString());
@@ -1456,7 +1457,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                         instanceNotFoundException(response.e);
                         introspectionException(response.e);
                         reflectionException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -1499,7 +1500,7 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
                             return response.value;
                         }
                         instanceNotFoundException(response.e);
-                        runtimeMBeanException(response.e);
+                        jmRuntimeException(response.e);
                         throw toIoException(response.e);
                     default:
                         throw new IOException("Unable to obtain isRegistered, status=" + result.toString());
@@ -1569,9 +1570,9 @@ class ClientConnection extends ClientCommon implements VersionedConnection {
             }
         }
 
-        private void runtimeMBeanException(Exception e) {
-            if (e instanceof RuntimeMBeanException) {
-                throw (RuntimeMBeanException) e;
+        private void jmRuntimeException(Exception e) {
+            if (e instanceof JMRuntimeException) {
+                throw (JMRuntimeException) e;
             }
         }
     }


### PR DESCRIPTION
Discussing with Brian we decided that the client should propagate JMRuntimeException rather than RuntimeMBeanException. The reason is JMRuntimeException is the parent for a bunch of useful exceptions, and JMRuntimeException itself does not require a cause in the constructor.
