### PR TITLE
Change scope of logmanager dependency to test only.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <version>1.5.0.Final</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
Stops the logmanager from be transitively included.
