### PR TITLE
REMJMX-92 Fix HTTPS Protocol

### DIFF
--- a/src/main/java/org/jboss/remotingjmx/RemotingConnectorProvider.java
+++ b/src/main/java/org/jboss/remotingjmx/RemotingConnectorProvider.java
@@ -46,7 +46,7 @@ public class RemotingConnectorProvider implements JMXConnectorProvider {
     public JMXConnector newJMXConnector(JMXServiceURL serviceURL, Map<String, ?> environment) throws IOException {
         String protocol = serviceURL.getProtocol();
 
-        if (PROTOCOL.equals(protocol) || HTTP_PROTOCOL.equals(protocol) || HTTPS_PROTOCOL.equals(PROTOCOL)) {
+        if (PROTOCOL.equals(protocol) || HTTP_PROTOCOL.equals(protocol) || HTTPS_PROTOCOL.equals(protocol)) {
             return new RemotingConnector(serviceURL, environment);
         }
 


### PR DESCRIPTION
The HTTPS protocol (https-remoting-jmx) is currently not working
because of a broken protocol check.

 * fix protocol check to support HTTPS protocol

Issue: REMJMX-92
https://issues.jboss.org/browse/REMJMX-92