### PR TITLE
[REMJMX-136] Do not use anonymous authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,11 +169,17 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <version>${version.org.jboss.logging.tools}</version>
+            <!-- Needed for compiling this project only -->
+            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <version>${version.org.jboss.logging.tools}</version>
+            <!-- Needed for compiling this project only -->
+            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>

--- a/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
+++ b/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
@@ -221,8 +221,6 @@ class RemotingConnector implements JMXConnector {
                 String[] credentials = (String[]) env.get(CREDENTIALS);
                 mergedConfiguration = mergedConfiguration.useName(credentials[0]).usePassword(credentials[1]).useRealm(null);
                 disabledMechanisms.add(JBOSS_LOCAL_USER);
-            } else {
-                mergedConfiguration = mergedConfiguration.useAnonymous();
             }
         }
 


### PR DESCRIPTION
First commit just changes the exposed scope of the logging processor.

Second commit removes making the authentication context anonymous.