### PR TITLE
[JBEAP-4587] remotingjmx client fails to work when the JVM is running…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
-            <version>4.0.23.Final-SNAPSHOT</version>
+            <version>4.0.22.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
-            <version>4.0.8.Final</version>
+            <version>4.0.23.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>

--- a/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
+++ b/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
@@ -236,7 +236,7 @@ class RemotingConnector implements JMXConnector {
         }
 
         // open a connection
-        final IoFuture<Connection> futureConnection = endpoint.connect(convert(serviceUrl), getOptionMap(disabledMechanisms), handler);
+        final IoFuture<Connection> futureConnection = endpoint.connect(convert(serviceUrl), getOptionMap(disabledMechanisms, env), handler);
         IoFuture.Status result = futureConnection.await(getTimeoutValue(Timeout.CONNECTION, env), TimeUnit.SECONDS);
 
         if (result == IoFuture.Status.DONE) {
@@ -250,7 +250,7 @@ class RemotingConnector implements JMXConnector {
         return connection;
     }
 
-    private OptionMap getOptionMap(Set<String> disabledMechanisms) {
+    private OptionMap getOptionMap(Set<String> disabledMechanisms, Map<String, ?> env) {
         OptionMap.Builder builder = OptionMap.builder();
         builder.set(SASL_POLICY_NOANONYMOUS, Boolean.FALSE);
         builder.set(SASL_POLICY_NOPLAINTEXT, Boolean.FALSE);
@@ -261,6 +261,18 @@ class RemotingConnector implements JMXConnector {
 
         builder.set(Options.SSL_ENABLED, true);
         builder.set(Options.SSL_STARTTLS, true);
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS, Boolean.valueOf(String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS.getName()))));
+        }
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD, String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD.getName())));
+        }
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL, String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL.getName())));
+        }
 
         if (disabledMechanisms != null && disabledMechanisms.size() > 0) {
             builder.set(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(disabledMechanisms));


### PR DESCRIPTION
… in FIPS mode

JBEAP: https://issues.jboss.org/browse/JBEAP-4587
Upstream (EAP 7.1, WF): https://issues.jboss.org/browse/REMJMX-142
PR (EAP 7.1, WF): https://github.com/jbossas/remoting-jmx/commit/fdf793ae17444e6c20a7956dfe6339d33a2538fc

jboss-remoting newer component is necessary (this is the reason of SNAPSHOT version)