### PR TITLE
[BZ-1335299] [GSS] (6.4.z) remotingjmx client fails to work when the …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.jboss.remoting3</groupId>
             <artifactId>jboss-remoting</artifactId>
-            <version>3.3.3.Final</version>
+            <version>3.3.9.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>

--- a/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
+++ b/src/main/java/org/jboss/remotingjmx/RemotingConnector.java
@@ -227,7 +227,7 @@ class RemotingConnector implements JMXConnector {
         }
 
         // open a connection
-        final IoFuture<Connection> futureConnection = endpoint.connect(convert(serviceUrl), getOptionMap(disabledMechanisms), handler);
+        final IoFuture<Connection> futureConnection = endpoint.connect(convert(serviceUrl), getOptionMap(disabledMechanisms, env), handler);
         IoFuture.Status result = futureConnection.await(getTimeoutValue(Timeout.CONNECTION, env), TimeUnit.SECONDS);
 
         if (result == IoFuture.Status.DONE) {
@@ -241,7 +241,7 @@ class RemotingConnector implements JMXConnector {
         return connection;
     }
 
-    private OptionMap getOptionMap(Set<String> disabledMechanisms) {
+    private OptionMap getOptionMap(Set<String> disabledMechanisms, Map<String, ?> env) {
         OptionMap.Builder builder = OptionMap.builder();
         builder.set(SASL_POLICY_NOANONYMOUS, Boolean.FALSE);
         builder.set(SASL_POLICY_NOPLAINTEXT, Boolean.FALSE);
@@ -252,6 +252,18 @@ class RemotingConnector implements JMXConnector {
 
         builder.set(Options.SSL_ENABLED, true);
         builder.set(Options.SSL_STARTTLS, true);
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS, Boolean.valueOf(String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS.getName()))));
+        }
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD , String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD.getName())));
+        }
+
+        if(env.containsKey(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL.getName())) {
+            builder.set(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL , String.valueOf(env.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL.getName())));
+        }
 
         if (disabledMechanisms != null && disabledMechanisms.size() > 0) {
             builder.set(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(disabledMechanisms));


### PR DESCRIPTION
…JVM is running in FIPS mode

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1335299
Upstream (EAP 7.0): https://issues.jboss.org/browse/JBEAP-4587
Upstream (EAP 7.1, WF): https://issues.jboss.org/browse/REMJMX-142
PR (EAP 7.0): https://github.com/jboss-remoting/jboss-remoting/pull/114
                        https://github.com/jbossas/remoting-jmx/pull/30
PR (EAP 7.1, WF): jbossas/remoting-jmx@fdf793a

Version of jBoss-remoting dependency has to contain change from this PR: https://github.com/jboss-remoting/jboss-remoting/pull/115
Component upgrade containing this change is not available at this time. Version of jboss-remoting was changed to last final version.
Link to PR with component update (once it exists) will be added.