### PR TITLE
[3.x branch] REM3-317 - Override the write(byte[]) variants on the OutputStream for improved performance

### DIFF
--- a/src/main/java/org/jboss/remotingjmx/protocol/v2/Common.java
+++ b/src/main/java/org/jboss/remotingjmx/protocol/v2/Common.java
@@ -83,6 +83,16 @@ abstract class Common {
         final org.jboss.marshalling.Marshaller marshaller = this.getMarshaller(marshallerFactory);
         final OutputStream outputStream = new OutputStream() {
             @Override
+            public void write(final byte[] b) throws IOException {
+                dataOutput.write(b);
+            }
+
+            @Override
+            public void write(final byte[] b, final int off, final int len) throws IOException {
+                dataOutput.write(b, off, len);
+            }
+
+            @Override
             public void write(int b) throws IOException {
                 final int byteToWrite = b & 0xff;
                 dataOutput.write(byteToWrite);


### PR DESCRIPTION

The commit here relates to https://issues.jboss.org/browse/REM3-317 and overrides the `write` methods of the `OutputStream` to avoid writing one byte at a time to the underlying stream.

Note that this in itself, probably won't solve the https://issues.jboss.org/browse/REM3-317 since I haven't yet generated/run proper performance tests to see where else fixes/improvements can be done. This one, however, looked like a straightforward fix that I think makes sense.

