### PR TITLE
[REMJMX-158] Always reuse serverMessageInterceptor when closing channel

### DIFF
--- a/src/main/java/org/jboss/remotingjmx/protocol/v2/ServerCommon.java
+++ b/src/main/java/org/jboss/remotingjmx/protocol/v2/ServerCommon.java
@@ -202,12 +202,40 @@ public abstract class ServerCommon extends Common {
 
         public void handleError(Channel channel, IOException error) {
             log.warn("Channel closing due to error", error);
-            end();
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        serverMessageInterceptor.handleEvent(new Event() {
+                            @Override
+                            public void run() {
+                                end();
+                            }
+                        });
+                    } catch (IOException e) {
+                        log.error(e);
+                    }
+                }
+            });
         }
 
         @Override
-        public void handleEnd(Channel channel) {
-            end();
+        public void handleEnd(final Channel channel) {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        serverMessageInterceptor.handleEvent(new Event() {
+                            @Override
+                            public void run() {
+                                end();
+                            }
+                        });
+                    } catch (IOException e) {
+                        log.error(e);
+                    }
+                }
+            });
         }
 
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/REMJMX-158